### PR TITLE
Use ssh for source url

### DIFF
--- a/SRGMediaPlayer.podspec
+++ b/SRGMediaPlayer.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.authors               = { "Frédéric Humbert-Droz" => "fred.hd@me.com", "Cédric Luthi" => "cedric.luthi@rts.ch", "Cédric Foellmi" => "cedric@onekilopars.ec", "Samuel Défago" => "defagos@gmail.com", "Pierre-Yves Bertholon" => "py.bertholon@gmail.com" }
   s.license	              = { :type => 'MIT' }
 
-  s.source                = { :git => "https://github.com/SRGSSR/SRGMediaPlayer-iOS.git", :branch => "master", :tag => "#{s.version}" }
+  s.source                = { :git => "git@github.com:SRGSSR/SRGMediaPlayer-iOS.git", :branch => "master", :tag => "#{s.version}" }
 
   s.ios.deployment_target = "8.0"
   s.requires_arc          = true


### PR DESCRIPTION
This ensure the use of a ssh key when executing pod install instead of typing the user and password initially.