### PR TITLE
Disable flaky test

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/SRGMediaPlayer.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/SRGMediaPlayer.xcscheme
@@ -73,6 +73,9 @@
                   Identifier = "PlaybackTestCase/testFixedStreamEndWithBuggyAkamaiMLS3StreamWithSubtitles">
                </Test>
                <Test
+                  Identifier = "PlaybackTestCase/testNonStreamedMediaPlayback">
+               </Test>
+               <Test
                   Identifier = "PlaybackTestCase/testOnDemandPlaybackStartAtTimeWithTolerances">
                </Test>
                <Test

--- a/Tests/SRGMediaPlayerTests/PlaybackTestCase.m
+++ b/Tests/SRGMediaPlayerTests/PlaybackTestCase.m
@@ -844,6 +844,7 @@ static NSURL *AudioOverHTTPTestURL(void)
 
 - (void)testNonStreamedMediaPlayback
 {
+#warning "This test fails in the iOS and tvOS simulator since Mac OS 13.4, see issue #124"
     [self expectationForSingleNotification:SRGMediaPlayerPlaybackStateDidChangeNotification object:self.mediaPlayerController handler:^BOOL(NSNotification * _Nonnull notification) {
         XCTAssertEqual([notification.userInfo[SRGMediaPlayerPlaybackStateKey] integerValue], SRGMediaPlayerPlaybackStatePreparing);
         XCTAssertFalse([notification.userInfo[SRGMediaPlayerSelectedKey] boolValue]);


### PR DESCRIPTION
### Motivation and Context

Documented in issue #124.

### Description

- Disable `testNonStreamedMediaPlayback` test.

### Checklist

- [x] The branch should be rebased onto the `develop` branch for whole tests with nighties.
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.

