### PR TITLE
Valid time interval to NSDateComponentsFormatter

### DIFF
--- a/Sources/SRGMediaPlayer/SRGTimeSlider~ios.m
+++ b/Sources/SRGMediaPlayer/SRGTimeSlider~ios.m
@@ -23,10 +23,6 @@ static void commonInit(SRGTimeSlider *self);
 
 static NSString *SRGTimeSliderFormatter(NSTimeInterval seconds)
 {
-    NSCAssert(seconds >= 0, @"A non-negative number of seconds is expected");
-    NSCAssert(!isnan(seconds), @"A number of seconds is expected");
-    NSCAssert(!isinf(seconds), @"A non-infinite number of seconds is expected");
-    
     if (seconds < 60. * 60.) {
         static NSDateComponentsFormatter *s_dateComponentsFormatter;
         static dispatch_once_t s_onceToken;

--- a/Sources/SRGMediaPlayer/SRGTimeSlider~ios.m
+++ b/Sources/SRGMediaPlayer/SRGTimeSlider~ios.m
@@ -23,6 +23,8 @@ static void commonInit(SRGTimeSlider *self);
 static NSString *SRGTimeSliderFormatter(NSTimeInterval seconds)
 {
     NSCAssert(seconds >= 0, @"A non-negative number of seconds is expected");
+    NSCAssert(!isnan(seconds), @"A number of seconds is expected");
+    NSCAssert(!isinf(seconds), @"A non-infinite number of seconds is expected");
     
     if (seconds < 60. * 60.) {
         static NSDateComponentsFormatter *s_dateComponentsFormatter;
@@ -353,8 +355,14 @@ static NSString *SRGTimeSliderAccessibilityFormatter(NSTimeInterval seconds)
             }
             else {
                 NSTimeInterval interval = self.maximumValue - self.value;
-                self.timeLeftValueLabel.text = [NSString stringWithFormat:@"-%@", SRGTimeSliderFormatter(interval)];
-                self.timeLeftValueLabel.accessibilityLabel = [NSString stringWithFormat:SRGMediaPlayerAccessibilityLocalizedString(@"%@ remaining", @"Label on slider for time remaining"), SRGTimeSliderAccessibilityFormatter(interval)];
+                if (! (isnan(interval) || isinf(interval) || signbit(interval))) {
+                    self.timeLeftValueLabel.text = SRGTimeSliderFormatter(interval);
+                    self.timeLeftValueLabel.accessibilityLabel = [NSString stringWithFormat:SRGMediaPlayerAccessibilityLocalizedString(@"%@ remaining", @"Label on slider for time remaining"), SRGTimeSliderAccessibilityFormatter(interval)];
+                }
+                else {
+                    self.timeLeftValueLabel.text = SRGMediaPlayerNonLocalizedString(@"--:--");
+                    self.timeLeftValueLabel.accessibilityLabel = nil;
+                }
             }
         }
         else {

--- a/Sources/SRGMediaPlayer/SRGTimeSlider~ios.m
+++ b/Sources/SRGMediaPlayer/SRGTimeSlider~ios.m
@@ -13,6 +13,7 @@
 #import "CMTimeRange+SRGMediaPlayer.h"
 #import "MAKVONotificationCenter+SRGMediaPlayer.h"
 #import "NSBundle+SRGMediaPlayer.h"
+#import "NSDate+SRGMediaPlayer.h"
 #import "SRGMediaPlayerController+Private.h"
 #import "UIBezierPath+SRGMediaPlayer.h"
 
@@ -355,7 +356,7 @@ static NSString *SRGTimeSliderAccessibilityFormatter(NSTimeInterval seconds)
             }
             else {
                 NSTimeInterval interval = self.maximumValue - self.value;
-                if (! (isnan(interval) || isinf(interval) || signbit(interval))) {
+                if (SRG_NSTIMEINTERVAL_IS_VALID(interval) && interval >= 0) {
                     self.timeLeftValueLabel.text = SRGTimeSliderFormatter(interval);
                     self.timeLeftValueLabel.accessibilityLabel = [NSString stringWithFormat:SRGMediaPlayerAccessibilityLocalizedString(@"%@ remaining", @"Label on slider for time remaining"), SRGTimeSliderAccessibilityFormatter(interval)];
                 }

--- a/Sources/SRGMediaPlayer/include/NSDate+SRGMediaPlayer.h
+++ b/Sources/SRGMediaPlayer/include/NSDate+SRGMediaPlayer.h
@@ -1,0 +1,16 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+@import Foundation;
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ *  `NSDateComponentsFormatter` cannot use NaN or infinity time interval. Use this macro to check.
+ */
+#define SRG_NSTIMEINTERVAL_IS_VALID(timeInterval) (!isnan(timeInterval) && !isinf(timeInterval))
+
+NS_ASSUME_NONNULL_END


### PR DESCRIPTION
### Motivation and Context

Documented in issue #127.

### Description

- Check `NSTimeInterval` is valid to `NSDateComponentsFormatter` and `SRGTimeSliderFormatter(NSTimeInterval seconds)` method.
- Add public macro, so that `SRGLetterbox` library could use it also for additional player UI controls. https://github.com/SRGSSR/srgletterbox-apple/pull/303

### Checklist

- [x] The branch should be rebased onto the `develop` branch for whole tests with last commits.
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.
