### PR TITLE
Fix seek bar layout on iOS 17

### DIFF
--- a/Sources/SRGMediaPlayer/SRGAirPlayButton~ios.m
+++ b/Sources/SRGMediaPlayer/SRGAirPlayButton~ios.m
@@ -211,8 +211,10 @@ static void commonInit(SRGAirPlayButton *self);
     BOOL hasImage = (image != nil);
     
     airPlayButton = self.routePickerView.srg_airPlayButton;
-    airPlayButton.imageView.contentMode = hasImage ? UIViewContentModeCenter : UIViewContentModeScaleToFill;
-    
+    dispatch_async(dispatch_get_main_queue(), ^{
+        airPlayButton.imageView.contentMode = hasImage ? UIViewContentModeCenter : UIViewContentModeScaleToFill;
+    });
+
     self.routePickerView.activeTintColor = self.activeTintColor;
     self.routePickerView.srg_isOriginalIconHidden = hasImage;
     


### PR DESCRIPTION
# Pull request

## Description

This PR allows us to fix a [layout issue](https://github.com/SRGSSR/srgmediaplayer-apple/assets/3347810/30f3bddd-2048-4bb9-bf18-613d15db5fa2) with the player seek bar.

## Changes made

- The access to the AirPlay's image view is now asynchronous.

## Checklist

- [x] The branch should be rebased onto the `develop` branch for whole tests with nighties.
- [x] The documentation has been updated (if relevant).
- [x] The demo has been updated (if relevant).
- [x] Issues are linked to the PR, if any.
