### PR TITLE
Always seek to the start position to mitigate impact of timestamp misalignments

### DIFF
--- a/Sources/SRGMediaPlayer/SRGMediaPlayerController.m
+++ b/Sources/SRGMediaPlayer/SRGMediaPlayerController.m
@@ -234,20 +234,9 @@ static AVMediaSelectionOption *SRGMediaPlayerControllerSubtitleForcedLanguageOpt
                     };
                     
                     SRGTimePosition *startTimePosition = [self timePositionForPosition:self.startPosition inSegment:self.targetSegment applyEndTolerance:YES];
-                    if (CMTIME_COMPARE_INLINE(startTimePosition.time, ==, kCMTimeZero)) {
-                        // Default position. Nothing to do.
-                        completionBlock(YES);
-                    }
-                    else {
-                        if (CMTIME_COMPARE_INLINE(startTimePosition.time, !=, kCMTimeZero)) {
-                            [player seekToTime:startTimePosition.time toleranceBefore:startTimePosition.toleranceBefore toleranceAfter:startTimePosition.toleranceAfter notify:NO completionHandler:^(BOOL finished) {
-                                completionBlock(finished);
-                            }];
-                        }
-                        else {
-                            completionBlock(YES);
-                        }
-                    }
+                    [player seekToTime:startTimePosition.time toleranceBefore:startTimePosition.toleranceBefore toleranceAfter:startTimePosition.toleranceAfter notify:NO completionHandler:^(BOOL finished) {
+                        completionBlock(finished);
+                    }];
                 }
             }
             else if (playerItem.status == AVPlayerItemStatusFailed) {


### PR DESCRIPTION
# Description

This PR mitigates the impact of timestamp misalignments in on-demand streams.

# Hints

We discovered an [issue](https://srgssr-ch.atlassian.net/browse/STXTBROAD-1268) with our new stream packaging solution based on AWS MediaPackage.

On-demand content currently delivered contains timestamps, which are not strictly excluded per RFC AFAWK but that [MUST be aligned between media playlists](https://datatracker.ietf.org/doc/html/rfc8216#section-6.2.4) if present. In our case the various media playlists have misaligned timestamps (sometimes off by more than a minute!) and we figured out that this makes the player start at different default positions (not necessarily zero) depending on the variant initially selected (sometimes more than a minute!). From a user perspective this means that depending on the player frame size (e.g. on iPad where Split View can be used) a faulty video can start at different locations, which is annoying.

A proper fix must be made on the packaging side, likely by AWS (a dedicated issue has been reported). Timestamps should either be aligned (AWS fix) or dropped (our choice). In our case they can be dropped since the content we usually publish has no use of timestamps (we are here namely talking about TV series or movies, as timestamps could make sense for on-demand content obtained as a result of a DVR playlist being ended). Either fix will take time, though, and affected videos (more than 3000 at RTS, less for other BUs) will not be processed again since they need to go through the whole upload / encoding / packaging workflow again, even though the issue is in the packaging itself.

We discovered, though, that our Pillarbox player is more resilient to this issue and could identify why. Pillarbox namely **always** sets a start position, even when it is the default one (zero). This has no noticeable negative effect on startup times (confirmed by having a look at Pillarbox startup metrics with / without the associated code) but ensures a more reliable behavior. This PR applies the same approach to SRG Media Player to make it resilient in the same way.

# Changes made

- Always set a startup position, even when starting at the default position.