### PR TITLE
Fix incorrect DVR stream start at position zero

### DIFF
--- a/Sources/SRGMediaPlayer/SRGMediaPlayerController.m
+++ b/Sources/SRGMediaPlayer/SRGMediaPlayerController.m
@@ -234,9 +234,12 @@ static AVMediaSelectionOption *SRGMediaPlayerControllerSubtitleForcedLanguageOpt
                     };
                     
                     SRGTimePosition *startTimePosition = [self timePositionForPosition:self.startPosition inSegment:self.targetSegment applyEndTolerance:YES];
-                    [player seekToTime:startTimePosition.time toleranceBefore:startTimePosition.toleranceBefore toleranceAfter:startTimePosition.toleranceAfter notify:NO completionHandler:^(BOOL finished) {
-                        completionBlock(finished);
-                    }];
+                    if (CMTIME_COMPARE_INLINE(startTimePosition.time, !=, kCMTimeZero) || self.streamType == SRGMediaPlayerStreamTypeOnDemand) {
+                        [player seekToTime:startTimePosition.time toleranceBefore:startTimePosition.toleranceBefore toleranceAfter:startTimePosition.toleranceAfter notify:NO completionHandler:completionBlock];
+                    }
+                    else {
+                        completionBlock(YES);
+                    }
                 }
             }
             else if (playerItem.status == AVPlayerItemStatusFailed) {


### PR DESCRIPTION
# Description

This PR fixes a regression introduced in #949. With the changes made DVR streams started at the default position would start at the DVR window origin, which is obviously incorrect.

# Changes made

- Take into account the stream type before forcing a seek at zero. Note that no unit test was added since we could not write one that fails, sadly.